### PR TITLE
Add CMS terraform

### DIFF
--- a/cms-terraform/.gitignore
+++ b/cms-terraform/.gitignore
@@ -1,0 +1,37 @@
+# Local .terraform directories
+**/.terraform/*
+
+# .tfstate files
+*.tfstate
+*.tfstate.*
+
+# Crash log files
+crash.log
+crash.*.log
+
+# Exclude all .tfvars files, which are likely to contain sensitive data, such as
+# password, private keys, and other secrets. These should not be part of version 
+# control as they are data points which are potentially sensitive and subject 
+# to change depending on the environment.
+*.tfvars
+*.tfvars.json
+
+# Ignore override files as they are usually used to override resources locally and so
+# are not checked in
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json
+
+# Ignore transient lock info files created by terraform apply
+.terraform.tfstate.lock.info
+
+# Include override files you do wish to add to version control using negated pattern
+# !example_override.tf
+
+# Include tfplan files to ignore the plan output of command: terraform plan -out=tfplan
+# example: *tfplan*
+
+# Ignore CLI configuration files
+.terraformrc
+terraform.rc

--- a/cms-terraform/.terraform.lock.hcl
+++ b/cms-terraform/.terraform.lock.hcl
@@ -1,0 +1,27 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/heroku/heroku" {
+  version     = "5.2.8"
+  constraints = "~> 5.0"
+  hashes = [
+    "h1:/VeVSq976Vcbya4xWRkCYGY4oWMNLB2n+kjAtttAOgM=",
+    "h1:2nPwhmyE4UmFU24VNKWr2f6kKp2sDEKYWzBpRl215pI=",
+    "zh:0aca7d8e57bb8c23e7a7e122408f1c46375f84671047f281562b1df76fec850f",
+    "zh:36a6f9bf29c5909f963a393bb1f3ea86ef7f6743205d4969b11e54e8f325b88a",
+    "zh:380599c1da3ffe74967dbe60d140900b405b5d4d3ac81ae52223a17a926ab9a5",
+    "zh:5dd595964d8bce76d08e44ff65a140da358f4bfea53d878640c5ca58147e127a",
+    "zh:70f2a7441913e5511c4ee7973b61c390b8befa4ddb6bfbac97b8eb08cfd07efe",
+    "zh:760fb47960ed13b81e4f281ef6cd10d691071f3f45711b4885b192beb3d237a4",
+    "zh:7b3785b69ab01bf76fb5feaa0fa806bd4671b4f15e7e7a0801b40730c086ef0e",
+    "zh:85c4a6db7d06ccd6abbf858da15235b75ad8fdcaf3b2a4e1c9e171a9a6ab627f",
+    "zh:918635702ae5e33c984b73096d42760a661a9c5670ae94500fa2391f8a409aec",
+    "zh:a542dda7daec593892233b13091e73c31167004481b951f2968d8adda6337b6c",
+    "zh:a783f3a6f24b483f0c249a6049c13bbd66db55861d18727f085330f8552efb0c",
+    "zh:b785f6102ec932fc3a588abbf9689f7a7020fc0966fce3ae4fa75c9ec2f8f39c",
+    "zh:d04ff26791eb021fbf08a37136f4a346ef56394d12b90a6c8f3d48beef40c1cb",
+    "zh:d3292f21c54d93dca27a4f6f06a8866e5a97093f839bade2ced8ace9bcd366f1",
+    "zh:e37a869305afb36c40f5b5f7898b52b8c8fd84f97002773fdc3cc24b97b15ada",
+    "zh:ed85f8914dc688c9768cc6436b48fb420b5eb950b10e8cba26ed209f5049f191",
+  ]
+}

--- a/cms-terraform/main.tf
+++ b/cms-terraform/main.tf
@@ -1,0 +1,19 @@
+terraform {
+  required_providers {
+    heroku = {
+      source  = "heroku/heroku"
+      version = "~> 5.0"
+    }
+  }
+}
+
+resource "heroku_app" "dream_renewables_strapi" {
+  name   = var.heroku_cms_app_name
+  region = "eu"
+}
+
+resource "heroku_addon" "strapi_postgres_db" {
+  name   = var.heroku_cms_db_name
+  app_id = heroku_app.dream_renewables_strapi.id
+  plan   = "heroku-postgresql:essential-1"
+}

--- a/cms-terraform/variables.tf
+++ b/cms-terraform/variables.tf
@@ -1,0 +1,9 @@
+variable "heroku_cms_app_name" {
+  description = "Name of the Heroku app"
+  default     = "dream-renewables-strapi"
+}
+
+variable "heroku_cms_db_name" {
+  description = "Name of the Heroku app db"
+  default     = "dream-renewables-strapi-postgres-db"
+}


### PR DESCRIPTION
# Context

- Previously the terraform for the CMS lived in the CMS repo. With moving to a Poly Repo system I want all of my infrastructure to exist in this Repo and as a result I needed to move the pre-existing terraform to this repo

## Changes proposed in this PR

- Copy CMS Repo
- Import existing architecture to avoid recreation
