### PR TITLE
Provision SES and server IAM user

### DIFF
--- a/server-terraform/.terraform.lock.hcl
+++ b/server-terraform/.terraform.lock.hcl
@@ -1,6 +1,29 @@
 # This file is maintained automatically by "terraform init".
 # Manual edits may be lost in future updates.
 
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.98.0"
+  constraints = "~> 5.0"
+  hashes = [
+    "h1:ezrzSKBDzk8N5TOmbLqkIBj1q/Uc+70pXwZ6J5yIEFg=",
+    "zh:23377bd90204b6203b904f48f53edcae3294eb072d8fc18a4531c0cde531a3a1",
+    "zh:2e55a6ea14cc43b08cf82d43063e96c5c2f58ee953c2628523d0ee918fe3b609",
+    "zh:4885a817c16fdaaeddc5031edc9594c1f300db0e5b23be7cd76a473e7dcc7b4f",
+    "zh:6ca7177ad4e5c9d93dee4be1ac0792b37107df04657fddfe0c976f36abdd18b5",
+    "zh:78bf8eb0a67bae5dede09666676c7a38c9fb8d1b80a90ba06cf36ae268257d6f",
+    "zh:874b5a99457a3f88e2915df8773120846b63d820868a8f43082193f3dc84adcb",
+    "zh:95e1e4cf587cde4537ac9dfee9e94270652c812ab31fce3a431778c053abf354",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:a75145b58b241d64570803e6565c72467cd664633df32678755b51871f553e50",
+    "zh:aa31b13d0b0e8432940d6892a48b6268721fa54a02ed62ee42745186ee32f58d",
+    "zh:ae4565770f76672ce8e96528cbb66afdade1f91383123c079c7fdeafcb3d2877",
+    "zh:b99f042c45bf6aa69dd73f3f6d9cbe0b495b30442c526e0b3810089c059ba724",
+    "zh:bbb38e86d926ef101cefafe8fe090c57f2b1356eac9fc5ec81af310c50375897",
+    "zh:d03c89988ba4a0bd3cfc8659f951183ae7027aa8018a7ca1e53a300944af59cb",
+    "zh:d179ef28843fe663fc63169291a211898199009f0d3f63f0a6f65349e77727ec",
+  ]
+}
+
 provider "registry.terraform.io/heroku/heroku" {
   version     = "5.2.8"
   constraints = "~> 5.0"

--- a/server-terraform/heroku-app.tf
+++ b/server-terraform/heroku-app.tf
@@ -1,0 +1,21 @@
+resource "heroku_app" "dream_renewables_server" {
+  name   = var.heroku_server_app_name
+  region = "eu"
+}
+
+resource "heroku_config" "server_service_config" {
+  vars = {
+    AWS_REGION = "eu-west-2"
+  }
+
+  sensitive_vars = {
+    AWS_ACCESS_KEY_ID     = aws_iam_access_key.server_service_access_key.id
+    AWS_SECRET_ACCESS_KEY = aws_iam_access_key.server_service_access_key.secret
+  }
+}
+
+resource "heroku_app_config_association" "dream_renewables_server_config_association" {
+  app_id         = heroku_app.dream_renewables_server.id
+  vars           = heroku_config.server_service_config.vars
+  sensitive_vars = heroku_config.server_service_config.sensitive_vars
+}

--- a/server-terraform/iam.tf
+++ b/server-terraform/iam.tf
@@ -1,0 +1,25 @@
+resource "aws_iam_user" "server_service_user" {
+  name = "server-service-user"
+}
+
+resource "aws_iam_access_key" "server_service_access_key" {
+  user = aws_iam_user.server_service_user.name
+}
+
+resource "aws_iam_user_policy" "server_ses_policy" {
+  name   = "ServerSESAccess"
+  user   = aws_iam_user.server_service_user.name
+  policy = data.aws_iam_policy_document.server_ses_policy.json
+}
+
+data "aws_iam_policy_document" "server_ses_policy" {
+  statement {
+    sid    = "AllowSendEmail"
+    effect = "Allow"
+    actions = [
+      "ses:SendEmail",
+      "ses:SendRawEmail"
+    ]
+    resources = ["*"]
+  }
+}

--- a/server-terraform/main.tf
+++ b/server-terraform/main.tf
@@ -4,10 +4,14 @@ terraform {
       source  = "heroku/heroku"
       version = "~> 5.0"
     }
+
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
   }
 }
 
-resource "heroku_app" "dream_renewables_server" {
-  name   = var.heroku_server_app_name
-  region = "eu"
+provider "aws" {
+  region = "eu-west-2"
 }

--- a/server-terraform/ses.tf
+++ b/server-terraform/ses.tf
@@ -1,0 +1,3 @@
+resource "aws_ses_email_identity" "alex_test_email" {
+  email = "alexanderpope27@gmail.com"
+}


### PR DESCRIPTION
# Context

- We want to be able to send emails with Stripe customer management links, this requires an email provider and as a result AWS SES made sense given experience with the technology, low costs and additionally we already have AWS resources provisioned

## Changes proposed in this PR

- Create new server IAM role
- Create new SES provision to use
